### PR TITLE
fix non-static field get and set

### DIFF
--- a/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PostfixUnary.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/Expression/UnaryExpression.PostfixUnary.cs
@@ -169,7 +169,7 @@ internal partial class MethodConvert
 
     private void ConvertPropertyIdentifierNamePostIncrementOrDecrementExpression(SemanticModel model, SyntaxToken operatorToken, IPropertySymbol symbol)
     {
-        if (symbol.IsStatic)
+        if (!NeedInstanceConstructor(symbol.GetMethod!))
         {
             CallMethodWithConvention(model, symbol.GetMethod!);
             AddInstruction(OpCode.DUP);

--- a/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
+++ b/src/Neo.Compiler.CSharp/MethodConvert/PropertyConvert.cs
@@ -42,7 +42,7 @@ internal partial class MethodConvert
     private void ConvertFieldBackedProperty(IPropertySymbol property)
     {
         IFieldSymbol[] fields = property.ContainingType.GetAllMembers().OfType<IFieldSymbol>().ToArray();
-        if (Symbol.IsStatic)
+        if (!NeedInstanceConstructor(Symbol))
         {
             IFieldSymbol backingField = Array.Find(fields, p => SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property))!;
             byte backingFieldIndex = _context.AddStaticField(backingField);
@@ -61,8 +61,6 @@ internal partial class MethodConvert
         }
         else
         {
-            if (!NeedInstanceConstructor(Symbol))
-                return;
             fields = fields.Where(p => !p.IsStatic).ToArray();
             int backingFieldIndex = Array.FindIndex(fields, p => SymbolEqualityComparer.Default.Equals(p.AssociatedSymbol, property));
             switch (Symbol.MethodKind)

--- a/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Property.cs
+++ b/tests/Neo.Compiler.CSharp.UnitTests/TestingArtifacts/Contract_Property.cs
@@ -10,12 +10,12 @@ public abstract class Contract_Property(Neo.SmartContract.Testing.SmartContractI
 {
     #region Compiled data
 
-    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Property"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""symbol"",""parameters"":[],""returntype"":""String"",""offset"":0,""safe"":false},{""name"":""testStaticPropertyInc"",""parameters"":[],""returntype"":""Integer"",""offset"":14,""safe"":false},{""name"":""testPropertyInc"",""parameters"":[],""returntype"":""Integer"",""offset"":31,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":47,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
+    public static Neo.SmartContract.Manifest.ContractManifest Manifest => Neo.SmartContract.Manifest.ContractManifest.Parse(@"{""name"":""Contract_Property"",""groups"":[],""features"":{},""supportedstandards"":[],""abi"":{""methods"":[{""name"":""symbol"",""parameters"":[],""returntype"":""String"",""offset"":0,""safe"":false},{""name"":""testStaticPropertyInc"",""parameters"":[],""returntype"":""Integer"",""offset"":14,""safe"":false},{""name"":""testPropertyInc"",""parameters"":[],""returntype"":""Integer"",""offset"":31,""safe"":false},{""name"":""_initialize"",""parameters"":[],""returntype"":""Void"",""offset"":48,""safe"":false}],""events"":[]},""permissions"":[],""trusts"":[],""extra"":{""nef"":{""optimization"":""All""}}}");
 
     /// <summary>
     /// Optimization: "All"
     /// </summary>
-    public static Neo.SmartContract.NefFile Nef => Neo.IO.Helper.AsSerializable<Neo.SmartContract.NefFile>(Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADIMC1Rva2VuU3ltYm9sQFhKnGBFWEqcYEVYSpxgRVhAeEpOnEV4Sk6cRXhKTpxFQFYBQPfo8yI="));
+    public static Neo.SmartContract.NefFile Nef => Neo.IO.Helper.AsSerializable<Neo.SmartContract.NefFile>(Convert.FromBase64String(@"TkVGM1Rlc3RpbmdFbmdpbmUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADMMC1Rva2VuU3ltYm9sQFhKnGBFWEqcYEVYSpxgRVhAWUqcYUVZSpxhRVlKnGFFWUBWAkA1Yowb"));
 
     #endregion
 
@@ -31,23 +31,24 @@ public abstract class Contract_Property(Neo.SmartContract.Testing.SmartContractI
     /// Unsafe method
     /// </summary>
     /// <remarks>
-    /// Script: eEpOnEV4Sk6cRXhKTpxFQA==
-    /// 00 : OpCode.LDARG0 [2 datoshi]
+    /// Script: WUqcYUVZSpxhRVlKnGFFWUA=
+    /// 00 : OpCode.LDSFLD1 [2 datoshi]
     /// 01 : OpCode.DUP [2 datoshi]
-    /// 02 : OpCode.TUCK [2 datoshi]
-    /// 03 : OpCode.INC [4 datoshi]
+    /// 02 : OpCode.INC [4 datoshi]
+    /// 03 : OpCode.STSFLD1 [2 datoshi]
     /// 04 : OpCode.DROP [2 datoshi]
-    /// 05 : OpCode.LDARG0 [2 datoshi]
+    /// 05 : OpCode.LDSFLD1 [2 datoshi]
     /// 06 : OpCode.DUP [2 datoshi]
-    /// 07 : OpCode.TUCK [2 datoshi]
-    /// 08 : OpCode.INC [4 datoshi]
+    /// 07 : OpCode.INC [4 datoshi]
+    /// 08 : OpCode.STSFLD1 [2 datoshi]
     /// 09 : OpCode.DROP [2 datoshi]
-    /// 0A : OpCode.LDARG0 [2 datoshi]
+    /// 0A : OpCode.LDSFLD1 [2 datoshi]
     /// 0B : OpCode.DUP [2 datoshi]
-    /// 0C : OpCode.TUCK [2 datoshi]
-    /// 0D : OpCode.INC [4 datoshi]
+    /// 0C : OpCode.INC [4 datoshi]
+    /// 0D : OpCode.STSFLD1 [2 datoshi]
     /// 0E : OpCode.DROP [2 datoshi]
-    /// 0F : OpCode.RET [0 datoshi]
+    /// 0F : OpCode.LDSFLD1 [2 datoshi]
+    /// 10 : OpCode.RET [0 datoshi]
     /// </remarks>
     [DisplayName("testPropertyInc")]
     public abstract BigInteger? TestPropertyInc();


### PR DESCRIPTION
After this commit, the errors in `UnitTest_Property` become `Specified cast is not valid`. This is caused by incrementing null.